### PR TITLE
fix: extern to avoid multiple definition + yytext in parsing error

### DIFF
--- a/src/parser/owl2fsParser.y
+++ b/src/parser/owl2fsParser.y
@@ -28,9 +28,9 @@
 	
 	#define YYSTYPE Expression
 
-	char* yytext;
+	extern char* yytext;
 	int yylex(void);
-	int yylineno;
+	extern int yylineno;
 	// void yyerror(TBox* tbox, ABox* abox, char* msg);
 	void yyerror(KB* kb, char* msg);
 	extern FILE *yyin;
@@ -638,7 +638,7 @@ NegativeDataPropertyAssertion:
 %%
 
 void yyerror(KB* kb, char* msg) {
-	fprintf(stderr, "\nline %d: %s\n", yylineno, msg);
+	fprintf(stderr, "\nline %d near %s: %s\n", yylineno, yytext, msg);
 }
 
 void unsupported_feature(char* feature) {


### PR DESCRIPTION
Hello,

I encountered an issue while compiling ELepHant.\
It is possible that the problem comes from using a different compiler version than the one you were using.

```
gcc -DHAVE_CONFIG_H -I. -I..    -O2 -Wall -g -O2 -MT elephant_reasoner-elephant-reasoner.o -MD -MP -MF .deps/elephant_reasoner-elephant-reasoner.Tpo -c -o elephant_reasoner-elephant-reasoner.o `test -f 'elephant-reasoner.c' || echo './'`elephant-reasoner.c
mv -f .deps/elephant_reasoner-elephant-reasoner.Tpo .deps/elephant_reasoner-elephant-reasoner.Po
gcc -O2 -Wall -g -O2   -o elephant-reasoner elephant_reasoner-elephant-reasoner.o reasoner/libreasoner.a parser/libowl2fsParser.a model/libmodel.a preprocessing/libpreprocessing.a index/libindex.a saturation/libsaturation.a hierarchy/libhierarchy.a hashing/libhashing.a utils/libutils.a   
/usr/bin/ld: parser/libowl2fsParser.a(owl2fsParser.o):/tmp/elephant-reasoner/src/parser/owl2fsParser.y:33: multiple definition of `yylineno'; parser/libowl2fsParser.a(owl2fsLexer.o):/tmp/elephant-reasoner/src/parser/owl2fsLexer.c:331: first defined here
/usr/bin/ld: parser/libowl2fsParser.a(owl2fsParser.o):/tmp/elephant-reasoner/src/parser/owl2fsParser.y:31: multiple definition of `yytext'; parser/libowl2fsParser.a(owl2fsLexer.o):/tmp/elephant-reasoner/src/parser/owl2fsLexer.c:1091: first defined here
collect2: error: ld returned 1 exit status
```

Here is how I produced the error:
```sh
aclocal
autoheader
autoconf
automake --add-missing
./configure
make
```

My gcc configuration
```
gcc -v 
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.1.1 20250425 (GCC)
```